### PR TITLE
Fix servient termination process

### DIFF
--- a/node-red-node-wot/src/servients/servient-manager.ts
+++ b/node-red-node-wot/src/servients/servient-manager.ts
@@ -37,7 +37,11 @@ export default class ServientManager {
                 console.warn("[warn] timeout happend while servient ending. id: " + id)
                 resolve()
             }, 10000) // If it does not end after 10 seconds, it is considered to be finished.
-            await servientWrapper.endServient()
+            try {
+                await servientWrapper.endServient()
+            } catch (err) {
+                reject(err)
+            }
             console.debug("[debug] servient ended. id: " + id)
             clearTimeout(timeoutId)
             resolve()

--- a/node-red-node-wot/src/servients/servient-manager.ts
+++ b/node-red-node-wot/src/servients/servient-manager.ts
@@ -39,12 +39,14 @@ export default class ServientManager {
             }, 10000) // If it does not end after 10 seconds, it is considered to be finished.
             try {
                 await servientWrapper.endServient()
+                console.debug("[debug] servient ended. id: " + id)
+                clearTimeout(timeoutId)
+                resolve()
             } catch (err) {
+                console.debug("[debug] failed to end servient. id: " + id + " error: " + err.toString())
+                clearTimeout(timeoutId)
                 reject(err)
             }
-            console.debug("[debug] servient ended. id: " + id)
-            clearTimeout(timeoutId)
-            resolve()
         })
     }
 


### PR DESCRIPTION
I did not catch the exception that occurred when termination Servient.
If an exception occurred when terminating Servient, then Node-RED would stop.
I have fixed the problem.