### PR TITLE
Fix read property set observe bug

### DIFF
--- a/node-red-node-wot/package.json
+++ b/node-red-node-wot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thingweb/node-red-node-wot",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Web of Things nodes for Node-RED using node-wot",
   "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
   "license": "MIT",

--- a/node-red-node-wot/plugin-resources-src/node-wot-plugin-lib.ts
+++ b/node-red-node-wot/plugin-resources-src/node-wot-plugin-lib.ts
@@ -88,6 +88,7 @@ export const createClientFlowUsingDashboard = (tdString: string, existedNodes: a
                 ...commonParams,
                 propertyName,
                 propertyDescription: tdProperty.description,
+                propertyObserve: tdProperty.observable,
                 inputMode: DATATYPES[tdProperty.type || "propertyTypeNull"].inputMode,
                 convert: DATATYPES[tdProperty.type || "propertyTypeNull"].typeConvert,
             }
@@ -595,7 +596,7 @@ const PROPERTY_READ_TEMP = `[
         "thing": "<%common-genid(1)%>",
         "property": "<%propertyName%>",
         "uriVariables": "{}",
-        "observe": true,
+        "observe": <%propertyObserve%>,
         "x": 480,
         "y": <%y1%>,
         "wires": [

--- a/node-red-node-wot/plugin-resources-src/node-wot-plugin-lib.ts
+++ b/node-red-node-wot/plugin-resources-src/node-wot-plugin-lib.ts
@@ -14,7 +14,7 @@ const DATATYPES = {
     },
     boolean: {
         inputMode: "text",
-        typeConvert: "String",
+        typeConvert: "JSON.parse",
     },
     object: {
         inputMode: "textarea",

--- a/node-red-node-wot/src/wot-property.html
+++ b/node-red-node-wot/src/wot-property.html
@@ -37,20 +37,7 @@
             $("div#property-row").hide()
 
             $("#node-input-property").change(function () {
-                let property = this.value
-                let thingID = $("select#node-input-thing").val()
-                if (thingID) {
-                    RED.nodes.eachConfig((config) => {
-                        if (config.id === thingID && config.td) {
-                            let properties = JSON.parse(config.td).properties || {}
-                            if (properties[property] && properties[property].observable) {
-                                $("div#property-observe").show()
-                            } else {
-                                $("div#property-observe").hide()
-                            }
-                        }
-                    })
-                }
+                showOrHideObserveCheckbox()
             })
 
             $("select#node-input-thing").change(function () {
@@ -60,6 +47,24 @@
                     hideOptions()
                 }
             })
+
+            function showOrHideObserveCheckbox() {
+                let property = $("#node-input-property").val()
+                let thingID = $("select#node-input-thing").val()
+                if (thingID) {
+                    RED.nodes.eachConfig((config) => {
+                        if (config.id === thingID && config.td) {
+                            let properties = JSON.parse(config.td).properties || {}
+                            if (properties[property] && properties[property].observable) {
+                                $("div#property-observe").show()
+                            } else {
+                                $("#node-input-observe").removeAttr("checked").prop("checked", false).change()
+                                $("div#property-observe").hide()
+                            }
+                        }
+                    })
+                }
+            }
 
             function showOptions() {
                 let thingID = $("select#node-input-thing").val()
@@ -86,6 +91,7 @@
                             })
                             // Show containing div
                             $("div#property-row").show()
+                            showOrHideObserveCheckbox()
                         }
                     })
                 }


### PR DESCRIPTION
There was a bug in the process of setting observe for a Read Property node.

* When a Read Property node is placed on the canvas, the configuration screen of the node is displayed, and the Thing is selected, one property is selected, but the observe checkbox is not displayed even if the property is observable.
* When observe is true in Read Property and a non-observable property is selected, the observe checkbox is hidden, but observe remains true internally, so when the flow is deployed, an error message stating that it cannot be observed is displayed. After deploying a flow, an error message stating that the flow is unobservable will be output all the time.
* When creating a flow from Create WoT Consumer flow, observe was true for the read-property node created, even though the property observable defined in the TD was false.
* In flows generated by the Create WoT Consumer flow plugin, bool values were being converted using `String(value)`, resulting in an error message stating that the type was different.Fixed to use `JSON.parse(value)` for conversion.